### PR TITLE
Test entities :)

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -190,4 +190,9 @@ describe('toHTML()', function () {
     node = h('br');
     assert.equal(toHTML(node), '<br>');
   });
+
+  it('should preserve UTF-8 entities', function () {
+    var node = h('span', null, '测试');
+    assert.equal(toHTML(node), '<span>测试</span>');
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -191,8 +191,8 @@ describe('toHTML()', function () {
     assert.equal(toHTML(node), '<br>');
   });
 
-  it('should preserve UTF-8 entities', function () {
-    var node = h('span', null, '测试');
-    assert.equal(toHTML(node), '<span>测试</span>');
+  it('should preserve UTF-8 entities and escape special html characters', function () {
+    var node = h('span', null, '测试&\"\'<>');
+    assert.equal(toHTML(node), '<span>测试&amp;&quot;&#39;&lt;&gt;</span>');
   });
 });


### PR DESCRIPTION
just to verify this module doesn't mess with UTF-8 entities unnecessarily, and provide a reference in case ppl get confused when `&amp;` is double-encoded into `&amp;amp;` (like me).