### PR TITLE
bump virtual-dom dependency, fix support for hooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,8 +60,7 @@ function openTag(node) {
   for (var name in hooks) {
     var hook = hooks[name];
     if (isVHook(hook)) {
-      var attr = createAttribute(name, hook.value, true);
-      if (attr) ret += ' ' + attr;
+      ret += ' ' + createAttribute(name, hook.value, true);
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -29,7 +29,6 @@ function toHTML(node, parent) {
 
 function openTag(node) {
   var props = node.properties;
-  var hooks = node.hooks;
   var ret = '<' + node.tagName.toLowerCase();
 
   for (var name in props) {
@@ -53,15 +52,13 @@ function openTag(node) {
       value = css.trim();
     }
 
+    if (isVHook(value)) {
+      ret += ' ' + createAttribute(name, value.value, true);
+      continue;
+    }
+
     var attr = createAttribute(name, value);
     if (attr) ret += ' ' + attr;
-  }
-
-  for (var name in hooks) {
-    var hook = hooks[name];
-    if (isVHook(hook)) {
-      ret += ' ' + createAttribute(name, hook.value, true);
-    }
   }
 
   return ret + '>';

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function openTag(node) {
       value = css.trim();
     }
 
-    if (isVHook(value)) {
+    if (isVHook(value) && value.namespace) {
       ret += ' ' + createAttribute(name, value.value, true);
       continue;
     }

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var escape = require('escape-html');
 var extend = require('xtend');
 var isVNode = require('virtual-dom/vnode/is-vnode');
 var isVText = require('virtual-dom/vnode/is-vtext');
+var isVHook = require('virtual-dom/vnode/is-vhook');
 var isThunk = require('virtual-dom/vnode/is-thunk');
 var paramCase = require('param-case');
 var createAttribute = require('./create-attribute');
@@ -28,6 +29,7 @@ function toHTML(node, parent) {
 
 function openTag(node) {
   var props = node.properties;
+  var hooks = node.hooks;
   var ret = '<' + node.tagName.toLowerCase();
 
   for (var name in props) {
@@ -53,6 +55,14 @@ function openTag(node) {
 
     var attr = createAttribute(name, value);
     if (attr) ret += ' ' + attr;
+  }
+
+  for (var name in hooks) {
+    var hook = hooks[name];
+    if (isVHook(hook)) {
+      var attr = createAttribute(name, hook.value, true);
+      if (attr) ret += ' ' + attr;
+    }
   }
 
   return ret + '>';

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "escape-html": "^1.0.1",
     "param-case": "^1.0.1",
-    "virtual-dom": "^1.1.0",
+    "virtual-dom": "^2.0.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -210,4 +210,12 @@ describe('toHTML()', function () {
     });
     assert.equal(toHTML(node), '<use xlink:href="/abc.jpg"></use>');
   });
+
+  it('should only render attribute hooks, by checking namespace', function () {
+    var node = svg('use', {
+      'xlink:href': '/abc.jpg'
+    });
+    node.hooks['xlink:href'].namespace = null;
+    assert.equal(toHTML(node), '<use></use>');
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@ var VNode = require('virtual-dom/vnode/vnode');
 var VText = require('virtual-dom/vnode/vtext');
 var h = require('virtual-dom/h');
 var svg = require('virtual-dom/virtual-hyperscript/svg');
+var svg = require('virtual-dom/virtual-hyperscript/svg');
 var partial = require('vdom-thunk');
 var assert = require('assert');
 var toHTML = require('..');
@@ -209,5 +210,13 @@ describe('toHTML()', function () {
       'xlink:href': '/abc.jpg'
     });
     assert.equal(toHTML(node), '<use xlink:href="/abc.jpg"></use>');
+  });
+
+  it('should only render valid hooks', function () {
+    var node = svg('svg');
+    node.hooks = {
+      'xlink:href': {}
+    };
+    assert.equal(toHTML(node), '<svg></svg>');
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,7 @@
 var VNode = require('virtual-dom/vnode/vnode');
 var VText = require('virtual-dom/vnode/vtext');
 var h = require('virtual-dom/h');
+var svg = require('virtual-dom/virtual-hyperscript/svg');
 var partial = require('vdom-thunk');
 var assert = require('assert');
 var toHTML = require('..');
@@ -194,5 +195,19 @@ describe('toHTML()', function () {
   it('should preserve UTF-8 entities and escape special html characters', function () {
     var node = h('span', null, '测试&\"\'<>');
     assert.equal(toHTML(node), '<span>测试&amp;&quot;&#39;&lt;&gt;</span>');
+  });
+
+  it('should render svg with attributes in default namespace', function () {
+    var node = svg('svg', {
+      'viewBox': '0 0 10 10'
+    });
+    assert.equal(toHTML(node), '<svg viewBox="0 0 10 10"></svg>');
+  });
+
+  it('should render svg with attributes in non-default namespace', function () {
+    var node = svg('use', {
+      'xlink:href': '/abc.jpg'
+    });
+    assert.equal(toHTML(node), '<use xlink:href="/abc.jpg"></use>');
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,6 @@ var VNode = require('virtual-dom/vnode/vnode');
 var VText = require('virtual-dom/vnode/vtext');
 var h = require('virtual-dom/h');
 var svg = require('virtual-dom/virtual-hyperscript/svg');
-var svg = require('virtual-dom/virtual-hyperscript/svg');
 var partial = require('vdom-thunk');
 var assert = require('assert');
 var toHTML = require('..');

--- a/test/test.js
+++ b/test/test.js
@@ -210,12 +210,4 @@ describe('toHTML()', function () {
     });
     assert.equal(toHTML(node), '<use xlink:href="/abc.jpg"></use>');
   });
-
-  it('should only render valid hooks', function () {
-    var node = svg('svg');
-    node.hooks = {
-      'xlink:href': {}
-    };
-    assert.equal(toHTML(node), '<svg></svg>');
-  });
 });


### PR DESCRIPTION
2 changes:

1. bump dependency of virtual-dom to 2.0, old tests still passes.
2. support svg with namespaced attributes, see added tests.