### PR TITLE
Render method on widgets to help convert to html

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,28 @@ toHTML(new VNode('input', { className: 'name', type: 'text' }));
 // => '<input class="name" type="text">'
 ```
 
+### Special case for Widgets
+
+>Widgets are used to take control of the patching process, allowing the user to create stateful components, control sub-tree rendering, and hook into element removal.
+[Documentation is available here](https://github.com/Matt-Esch/virtual-dom/blob/master/docs/widget.md).
+
+Widgets are given an opportunity to provide a vdom representation through an optional `render` method. If the `render` method is not found an empty string will be used instead.
+
+```js
+var Widget = function(text) {
+  this.text = text;
+}
+Widget.prototype.type = 'Widget';
+// provide a vdom representation of the widget
+Widget.prototype.render = function() {
+  return new VNode('span', null, [new VText(this.text)]);
+};
+// other widget prototype methods would be implemented
+
+toHTML(new Widget('hello'));
+// => '<span>hello</span>'
+```
+
 [npm-image]: https://img.shields.io/npm/v/vdom-to-html.svg?style=flat-square
 [npm-url]: https://npmjs.org/package/vdom-to-html
 [github-image]: http://img.shields.io/github/release/nthtran/vdom-to-html.svg?style=flat-square

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var extend = require('xtend');
 var isVNode = require('virtual-dom/vnode/is-vnode');
 var isVText = require('virtual-dom/vnode/is-vtext');
 var isThunk = require('virtual-dom/vnode/is-thunk');
+var isWidget = require('virtual-dom/vnode/is-widget');
 var softHook = require('virtual-dom/virtual-hyperscript/hooks/soft-set-hook');
 var attrHook = require('virtual-dom/virtual-hyperscript/hooks/attribute-hook');
 var paramCase = require('param-case');
@@ -15,6 +16,10 @@ function toHTML(node, parent) {
   if (!node) return '';
 
   if (isThunk(node)) {
+    node = node.render();
+  }
+
+  if (isWidget(node) && node.render) {
     node = node.render();
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -160,6 +160,18 @@ describe('toHTML()', function () {
     assert.equal(toHTML(node), '<span>hello</span>');
   });
 
+  it('should render widgets', function () {
+    var Widget = function(text) {
+      this.text = text;
+    }
+    Widget.prototype.type = 'Widget';
+    Widget.prototype.render = function() {
+      return new VNode('span', null, [new VText(this.text)]);
+    };
+    var node = new Widget('hello');
+    assert.equal(toHTML(node), '<span>hello</span>');
+  });
+
   it('should render tag in lowercase', function () {
     var node = new VNode('SPAN', null, [new VText('hello')]);
     assert.equal(toHTML(node), '<span>hello</span>');


### PR DESCRIPTION
This is a proposal to allow widgets an optional method called `render` that is called as part of toHTML. The `render` method on widgets would return vdom elements that are in turn parsed into html by vdom-to-html.

At the moment all widgets are turned into empty strings by vdom-to-html. This additional feature gives widgets the opportunity to provide a string representation of their content.

The method is currently `render` however any suggestion on an alternate name are most welcome.

I've added a test. The code changes are surprisingly small.