### PR TITLE
Skip properties that are functions

### DIFF
--- a/create-attribute.js
+++ b/create-attribute.js
@@ -45,7 +45,7 @@ function createAttribute(name, value, isAttribute) {
 
 function shouldSkip(name, value) {
   var attrType = properties[name];
-  return value == null ||
+  return value == null || typeof value === 'function' ||
     (attrType === types.BOOLEAN && !value) ||
     (attrType === types.OVERLOADED_BOOLEAN && value === false);
 }

--- a/test/test.js
+++ b/test/test.js
@@ -219,4 +219,11 @@ describe('toHTML()', function () {
     var node = h('input', { type: 'submit', value: 'add' });
     assert.equal(toHTML(node), '<input type="submit" value="add">');
   });
+
+  it('should skip properties that are functions', function () {
+    var node = h('div', {
+      toString: function () { return 'Just a div'; }
+    }, 'Test');
+    assert.equal(toHTML(node), '<div>Test</div>');
+  });
 });


### PR DESCRIPTION
Thanks for the great library!

I was running into this error:
```shell
/Users/Kyle/Documents/www/base-element/node_modules/vdom-to-html/create-attribute.js:26
    name = (attributeNames[name] || name).toLowerCase();
                                          ^
TypeError: (attributeNames[name] || name).toLowerCase is not a function
    at createAttribute (/Users/Kyle/Documents/www/base-element/node_modules/vdom-to-html/create-attribute.js:26:43)
    at openTag (/Users/Kyle/Documents/www/base-element/node_modules/vdom-to-html/index.js:69:16)
    at toHTML (/Users/Kyle/Documents/www/base-element/node_modules/vdom-to-html/index.js:27:12)
    at BaseElement.toString (/Users/Kyle/Documents/www/base-element/index.js:55:10)
    at index (/Users/Kyle/Documents/www/base-element/examples/server-side.js:30:19)
    at Server.<anonymous> (/Users/Kyle/Documents/www/base-element/examples/server-side.js:10:5)
    at emitTwo (events.js:87:13)
    at Server.emit (events.js:172:7)
    at HTTPParser.parserOnIncoming [as onIncoming] (_http_server.js:474:12)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:88:23)
```

Which is because I define my elements just using prototypes and pass down `h('div', elementInstance, 'text')`. All works fine until a function is defined, in this case `toString()` on my element.

I think it should instead just skip any properties that are functions. Thanks!