### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,16 +9,13 @@
   "dependencies": {
     "escape-html": "^1.0.1",
     "param-case": "^1.0.1",
+    "virtual-dom": "^2.0.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {
     "istanbul": "0",
     "mocha": "2",
-    "vdom-thunk": "^3.0.0",
-    "virtual-dom": "^2.0.0"
-  },
-  "peerDependencies": {
-    "virtual-dom": "^2.0.0"
+    "vdom-thunk": "^3.0.0"
   },
   "scripts": {
     "test": "mocha --reporter spec",


### PR DESCRIPTION
peerDependencies changed their behavior in npm3. They are not installed anymore, so virtual-dom has to be a dependency.
https://github.com/npm/npm/issues/6565