### PR TITLE
Fix for issue when style property is stored as string instead of hash in the VNode

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,12 +58,14 @@ function openTag(node) {
     }
 
     if (name == 'style') {
-      var css = '';
-      value = extend({}, value);
-      for (var styleProp in value) {
-        css += paramCase(styleProp) + ': ' + value[styleProp] + '; ';
+      if(typeof(value) === 'object') {
+        var css = '';
+        value = extend({}, value);
+        for (var styleProp in value) {
+          css += paramCase(styleProp) + ': ' + value[styleProp] + '; ';
+        }
+        value = css.trim();
       }
-      value = css.trim();
     }
 
     if (value instanceof softHook || value instanceof attrHook) {

--- a/test/test.js
+++ b/test/test.js
@@ -66,6 +66,13 @@ describe('toHTML()', function () {
     assert.equal(toHTML(node), '<div style="background: black; color: red;"></div>');
   });
 
+  it('should render string style property', function () {
+    var node = new VNode('div', {
+      style: "background: black; color: red;"
+    });
+    assert.equal(toHTML(node), '<div style="background: black; color: red;"></div>');
+  });
+
   it('should convert style property to param-case', function () {
     var node = new VNode('div', {
       style: {


### PR DESCRIPTION
This PR adds support for serializing nodes to HTML with styles stored in string form instead of hash form.
