### PR TITLE
Fix for problem outputting style elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,9 @@ function toHTML(node, parent) {
   if (isVNode(node)) {
     return openTag(node) + tagContent(node) + closeTag(node);
   } else if (isVText(node)) {
-    if (parent && parent.tagName.toLowerCase() === 'script') return String(node.text);
+    if (parent && (parent.tagName.toLowerCase() === 'script'
+        || parent.tagName.toLowerCase() === 'style'))
+      return String(node.text);
     return escape(String(node.text));
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -77,6 +77,13 @@ describe('toHTML()', function () {
     assert.equal(toHTML(node), '<div style="background: black; color: red; z-index: 1;"></div>');
   });
 
+  it('should render style element correctly', function(){
+    var node = new VNode('style',{},[
+        new VText(".logo {background-image: url('/mylogo.png');}")
+    ]);
+    assert.equal(toHTML(node),"<style>.logo {background-image: url('/mylogo.png');}</style>");
+  });
+
   it('should render data- attributes for dataset properties', function () {
     var node = new VNode('div', {
       dataset: {


### PR DESCRIPTION
I found that the content of the style elements was being escaped as if it were an HTML text node.  This causes problems with things like `background-image: url('my.png')` which are then output as `background-image: url(&#39;my.png&#39;)`.  Script tags were already being exempted from this escaping, so I've added style tags to that conditional as well and added a test case for this.